### PR TITLE
Revert fix/userimage doesnt render correct profile image

### DIFF
--- a/src/app/api/user/addPost/route.ts
+++ b/src/app/api/user/addPost/route.ts
@@ -40,7 +40,9 @@ export async function POST(request: Request) {
         const user = await User.findOne({ email });
         const lastPostId: number = user && user.posts.length > 0 && user.posts[0].id || 100;
         post.id = lastPostId + 1;
-        post.userId = user._id;
+        if(!(post.retweet)){
+            post.userId = user._id;
+        }
 
         user.posts = [post, ...user.posts];
 

--- a/src/components/Header/TwitterHeader.tsx
+++ b/src/components/Header/TwitterHeader.tsx
@@ -23,7 +23,7 @@ function TwitterHeader({ section }: { section: string }) {
                         <FaArrowRight style={{ fontSize: "1rem" }} />
                     </div>
                     :
-                    <div className='w-9 h-9 outline outline-2 outline-offset-2 outline-black dark:outline-white cursor-pointer ml-5 rounded-full'>
+                    <div className='w-9 h-9 outline outline-2 outline-offset-2 outline-black dark:outline-white cursor-pointer ml-5 rounded-full flex justify-center items-center'>
                         <UserImage
                             className='w-full h-full '
                             onClick={() => windowWidth <= 640 && dispatch(toggleResponsiveMenu())}

--- a/src/components/PostsSection/Post/Post.tsx
+++ b/src/components/PostsSection/Post/Post.tsx
@@ -30,11 +30,12 @@ function Post({ postContent, onLoad, options = true }: Props) {
 
     const [name, setName] = useState<string>('Unauthenticated');
     const [username, setUsername] = useState<string>('username');
+    const [userId, setUserId] = useState<string>('');
     const [retweetModal, setRetweetModal] = useState<boolean>(false);
     const [commentModal, setCommentModal] = useState<boolean>(false);
 
     const handleClick = (optionName: string) => {
-        if(user){
+        if (user) {
             if (optionName === 'likes') {
                 handleLikePost();
             } else if (optionName === 'retweets') {
@@ -71,7 +72,7 @@ function Post({ postContent, onLoad, options = true }: Props) {
     }
 
     const handleRedirectToPostPage = () => {
-        router.push(`/home/user/${postContent.userId}/post/${postContent.id}`)
+        router.push(`/home/user/${postContent.retweet ? userId : postContent.userId}/post/${postContent.id}`)
     }
 
     const handleDisabledOptions = () => {
@@ -85,12 +86,17 @@ function Post({ postContent, onLoad, options = true }: Props) {
     useEffect(() => {
         setName(user?.name || "Unauthenticated");
         setUsername(user?.username || "");
+        setUserId(user?._id || '')
     }, [user])
 
     return (
         <section className='w-full h-full min-h-[8rem] overflow-visible p-5 flex justify-start items-start flex-row flex-nowrap border-b border-primary-gray dark:border-primary-dark-gray transition-all'>
             <div className='w-12 h-full'>
-                <UserImage className='w-10 h-10' username={postContent.retweet ? name : postContent.name} userId={postContent.userId} />
+                <UserImage
+                    className='w-10 h-10'
+                    username={postContent.retweet ? name : postContent.name}
+                    userId={postContent.retweet ? userId : postContent.userId}
+                />
             </div>
             <div className='w-full h-full ml-4 flex justify-between items-start flex-col flex-nowrap'>
                 <div className='flex justify-start items-center flex-row flex-nowrap mb-1'>


### PR DESCRIPTION
# Revert Merge and Correct: #41 

## About the Pull Request

This pull request addresses a critical issue introduced by the recent merge of the "fix: UserImage component doesn't render the correct profile image" #44  pull request. The revert is necessary due to an error affecting post rendering and UserImage component functionality.

## Changes Made

### 1. Reversion of Recent Changes

#### Post Rendering Error:
- Identified and reverted the recent changes causing incorrect rendering of profile images in certain scenarios.

#### UserImage Component Logic:
- Temporarily reverted the UserImage component modifications to restore stability and functionality.

### 2. Correction of Endpoint Logic

#### api/user/addPost:
- Modified the endpoint logic to set the user id of the post to the current user id when the post is not a retweet.
- For retweets, the user id remains the same as the original post's owner.

### 3. Adjustment in Post Component

#### Post Component:
- Modified the Post component to utilize the current user's id when rendering retweets.
- For non-retweet posts, the component uses the data of the post passed as usual.

## Screenshots

![image](https://github.com/Matdweb/Twitter-Clone/assets/110640534/9645772b-0e84-4e6e-806e-904142cb0e4b)

## Impact Statement

The decision to revert recent changes was crucial to address the observed errors affecting post rendering and UserImage component behavior. By refining the logic of the api/user/addPost endpoint and adjusting the Post component, developers aim to ensure accurate rendering of profile images and maintain consistency in post-related functionalities.

## Additional Notes

The identified errors in post rendering and UserImage component functionality necessitated a temporary revert of recent changes. Developers are committed to promptly resolving these issues, and the corrections made in this pull request aim to ensure a seamless and reliable user experience.
